### PR TITLE
deps: updates wazero to 1.0.0-rc.2 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/pkg/profile v1.6.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.0
-	github.com/tetratelabs/wazero v1.0.0-pre.2
+	github.com/tetratelabs/wazero v1.0.0-rc.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-rc.2 h1:OA3UUynnoqxrjCQ94mpAtdO4/oMxFQVNL2BXDMOc66Q=
+github.com/tetratelabs/wazero v1.0.0-rc.2/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/instance.go
+++ b/instance.go
@@ -44,15 +44,15 @@ func createRuntime(ctx context.Context) (wazero.Runtime, api.Module, error) {
 	// Instantiate a Go-defined module named "env" that exports a function to
 	// log to the console.
 	_, err := rt.NewHostModuleBuilder("env").
-		ExportFunction("log", logString).
-		Instantiate(ctx, rt)
+		NewFunctionBuilder().WithFunc(logString).Export("log").
+		Instantiate(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Instantiate a WebAssembly module that imports the "log" function defined
 	// in "env" and exports "memory" and functions we'll use in this example.
-	mod, err := rt.InstantiateModuleFromBinary(ctx, wasmBytes)
+	mod, err := rt.Instantiate(ctx, wasmBytes)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,9 +131,9 @@ func (inst *Instance) processString(ctx context.Context, callFn string, input st
 	defer inst.mod.ExportedFunction("deallocate").Call(ctx, inputPtr, inputSize)
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !inst.mod.Memory().Write(ctx, uint32(inputPtr), []byte(input)) {
+	if !inst.mod.Memory().Write(uint32(inputPtr), []byte(input)) {
 		return "", errors.Errorf("Memory.Write(%d, %d) out of range of memory size %d",
-			inputPtr, inputSize, inst.mod.Memory().Size(ctx))
+			inputPtr, inputSize, inst.mod.Memory().Size())
 	}
 
 	// Finally, we get the greeting message "greet" printed. This shows how to
@@ -150,16 +150,16 @@ func (inst *Instance) processString(ctx context.Context, callFn string, input st
 	defer inst.mod.ExportedFunction("deallocate").Call(ctx, uint64(retPtr), uint64(retSize))
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := inst.mod.Memory().Read(ctx, retPtr, retSize)
+	bytes, ok := inst.mod.Memory().Read(retPtr, retSize)
 	if !ok {
 		return "", errors.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			retPtr, retSize, inst.mod.Memory().Size(ctx))
+			retPtr, retSize, inst.mod.Memory().Size())
 	}
 	return string(bytes), nil
 }
 
 func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
+	buf, ok := m.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-rc.2](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-rc.2) which notably
* is the final release candidate before 1.0 next Friday.
* improves instantiation performance (startup time)
* passes `os` package tests defined by Go.
* no longer supports importing unnamed modules.